### PR TITLE
Add Heroku Database Configuration for Production Environment 

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,4 +1,5 @@
 module.exports = {
+  use_environment_variable: true,
   development: {
     username: process.env.POSTGRES_USER,
     password: null,

--- a/config/db.js
+++ b/config/db.js
@@ -17,7 +17,7 @@ module.exports = {
   production: {
     username: 'root',
     password: null,
-    database: 'database_production',
+    database: process.env.DATABASE_URL,
     host: '127.0.0.1',
     dialect: 'postgres'
   }

--- a/middleware/db.js
+++ b/middleware/db.js
@@ -8,7 +8,7 @@ const dbConfig  = require(__dirname + '/../config/db.js')[env];
 var db          = null;
 
 if (dbConfig.use_env_variable) {
-  db = new Sequelize(process.env[dbConfig.use_env_variable]);
+  db = new Sequelize('postgres:/aqcsysjrixrhym:499b89fc9cf873dde71f8fcbe52d5fd3cab6ccd066a6b8b16205f56d9dab8d97@ec2-54-163-246-154.compute-1.amazonaws.com:5432/dec48n2kkdjcg0?ssl=true', {'dialect':'postgres', 'ssl':true, 'dialectOptions':{'ssl':{'require':true}}});
 } else {
   db = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, dbConfig);
 }

--- a/middleware/db.js
+++ b/middleware/db.js
@@ -8,7 +8,7 @@ const dbConfig  = require(__dirname + '/../config/db.js')[env];
 var db          = null;
 
 if (dbConfig.use_env_variable) {
-  db = new Sequelize('postgres:/aqcsysjrixrhym:499b89fc9cf873dde71f8fcbe52d5fd3cab6ccd066a6b8b16205f56d9dab8d97@ec2-54-163-246-154.compute-1.amazonaws.com:5432/dec48n2kkdjcg0?ssl=true', {'dialect':'postgres', 'ssl':true, 'dialectOptions':{'ssl':{'require':true}}});
+  db = new Sequelize(dbConfig.database + '?ssl=true', {'dialect':'postgres', 'ssl':true, 'dialectOptions':{'ssl':{'require':true}}});
 } else {
   db = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, dbConfig);
 }


### PR DESCRIPTION
* Adds variable `use_environment_variable` to the db.js file
  in the Config folder. Set to true to always point to the prod
  database
* Refactors the database connection information in middleware/db.js
* Adds environment variable DATABASE_URL to Production config/dg.js
* Updates middleware/db.js to use variables