### PR TITLE
Change Feed Sanitizer Allowed Tags and Attributes

### DIFF
--- a/middleware/helpers.js
+++ b/middleware/helpers.js
@@ -17,7 +17,10 @@ var feedSanitizer = (data) => {
   return data.map((item) => {
     item.duration = secondstotime(item.duration);
     item.title = sanitize(item.title);
-    item.description = sanitize(item.description);
+    item.description = sanitize(item.description, {
+      allowedTags: [/* 'a' */],
+      allowedAttributes: {/* 'a': [ 'href' ] */}
+    });
     return item;
   });
 };


### PR DESCRIPTION
* Removes anchor tag from allowed tags
* Removes href from allowed attributes

Note: settings are commented instead of removed for easy reversal.