### PR TITLE
Get new podcast episodes, fix issue with desc not saving to db, add podcast episode to return from getFeed

### DIFF
--- a/controllers/episodeController.js
+++ b/controllers/episodeController.js
@@ -135,10 +135,12 @@ module.exports = {
             if (user) {
               sequelize.db.query('INSERT INTO "UserEpisodes" ("UserId", "EpisodeId", "isInInbox", "createdAt", "updatedAt") VALUES (' + user.id + ', ' + episodeID + ', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);')
                 .then(function (data) {
-                  if (data) {
-                    res.status(201).send(data);
-                  } else {
-                    res.status(500).send('Error subscribing user to Episode: ' + req.body.episode.title);
+                  if (!req.body.helper) {
+                    if (data) {
+                      res.status(201).send(data);
+                    } else {
+                      res.status(500).send('Error subscribing user to Episode: ' + req.body.episode.title);
+                    }
                   }
                 });
             }

--- a/controllers/podcastController.js
+++ b/controllers/podcastController.js
@@ -21,6 +21,8 @@ module.exports = {
           return;
         }
         var episodes = helpers.feedSanitizer(podcast.episodes);
+        delete podcast.episodes;
+        episodes[0].podcast = podcast;
         console.log(chalk.yellow(req.user));
         res.status(200).send(episodes);
       });
@@ -130,7 +132,7 @@ module.exports = {
         if(episode) {
           sequelize.Episode.create({
             title: episode.title,
-            description: episode.subtitle,
+            description: episode.description,
             length: episode.duration,
             releaseDate: episode.pubDate,
             url: episode.enclosure.url,

--- a/middleware/getNewEpisodes.js
+++ b/middleware/getNewEpisodes.js
@@ -1,0 +1,61 @@
+const chalk         = require('chalk');
+const config        = require('../config/config');
+const sequelize     = require('../config/db');
+const helpers       = require('../middleware/helpers.js');
+const parsePodcast  = require('../middleware/node-podcast-parser');
+const request       = require('request');
+const Promise       = require('bluebird');
+const moment        = require('moment');
+const subscribe     = require('../controllers/episodeController.js').subscribe;
+
+
+module.exports = {
+
+  getNewEpisodes: (req, res) => {
+    sequelize.Podcast.findAll()
+    .then((podcasts) => {
+      var newEpisodes = [];
+      podcasts.forEach((podcast) => {
+        let lastTitle = '';
+        let lastDate = '';
+        let feedUrl = podcast.feedUrl;
+        sequelize.Episode.max('id', {where:{PodcastId: podcast.id}})
+        .then((id) => {
+          if (id) {
+            sequelize.Episode.findOne({where:{id: id}})
+            .then((episode) => {
+              lastTitle = episode.title;
+              lastDate = moment(episode.releaseDate).format('l');
+            })
+            .then(() => {
+              return helpers.getFeed(feedUrl);
+            })
+            .then((feed) => {
+              feed = feed.data;
+              feed.forEach((episode) => {
+                var published = moment(episode.published).format('l');
+                if(episode.title !== lastTitle && (moment(lastDate).isBefore(published) || lastDate === published)) {
+                  newEpisodes.push(episode);
+                }
+              })
+            })
+            .then(() => {
+              return sequelize.UserPodcast.findAll({where: {PodcastId: podcast.id}})
+            })
+            .then((records) => {
+              if (records) {
+                records.forEach((record) => {
+                  newEpisodes.forEach((newEpisode) => {
+                    var subscribed = subscribe({user: {id: record.dataValues.UserId, username: 'another user'}, body: {helper: true, episode: newEpisode, podcast: podcast.dataValues}});
+                    console.log(subscribed);
+                  })
+                })
+              } else {console.log('No subscribed users found.');}
+            })
+            .catch(console.log)
+          }
+        })
+      })
+    })
+  }
+}

--- a/middleware/helpers.js
+++ b/middleware/helpers.js
@@ -55,7 +55,9 @@ var asyncGetFeed = (feedUrl) => {
       parsePodcast(data, (err, data) => {
         if (err) {
           console.error(chalk.red('Parsing error', err));
-          return;
+          // should this be reject(err); instead of return? -M
+          reject(err);
+          // return;
         }
         data = feedSanitizer(data.episodes);
         //console.log(chalk.white(JSON.stringify(data, null, 2)));

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-jwt": "^5.1.0",
     "jsonwebtoken": "^7.3.0",
     "lodash": "^4.17.4",
+    "moment": "^2.18.1",
     "morgan": "^1.8.1",
     "node-podcast-parser": "^1.0.2",
     "path": "^0.12.7",

--- a/routers/podcasts.js
+++ b/routers/podcasts.js
@@ -2,9 +2,11 @@
 //const db = require('../middleware/db');
 const podcastRouter = require('express').Router();
 const podcastController = require('../controllers/podcastController.js');
+const updater = require('../middleware/getNewEpisodes.js');
 
 podcastRouter.get('/feeds', podcastController.getFeed);
 podcastRouter.get('/', podcastController.getSubscriptions);
 podcastRouter.post('/', podcastController.subscribe);
+podcastRouter.get('/newEpisodes', updater.getNewEpisodes)
 
 module.exports = podcastRouter;

--- a/server.js
+++ b/server.js
@@ -10,12 +10,16 @@ const playlistRouter = require('./routers/playlists');
 const secret = require('./config/secret.json');
 const jwt = require('jsonwebtoken');
 const app = express();
+const getNewEpisodes = require('./middleware/getNewEpisodes.js').getNewEpisodes;
 
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
 // AUTHENTICATION MIDDLEWEAR: comment out if testing without token in auth header
 app.use(function (req, res, next) {
+  if(req.url.includes('/inbox')){
+    getNewEpisodes();
+  }
   if(req.url.includes('/logout')) {
     delete req.user;
   }


### PR DESCRIPTION
- Podcast object is saved as a property on the first episode (this the was the most unobtrusive way to return this object without requiring any front end refactoring)
- Validation error being thrown by subscribe route - but update/subscribe to new episodes seems to be working (this should be resolved once bug in subscribe to episode route is fixed)
- Episode descriptions now being save to DB
